### PR TITLE
Remove use of Automapper

### DIFF
--- a/DflatMusicOrganizer/Dflat.Application.UnitTests/Services/JobServices/FileSourceFolderScanServiceTests.cs
+++ b/DflatMusicOrganizer/Dflat.Application.UnitTests/Services/JobServices/FileSourceFolderScanServiceTests.cs
@@ -1,10 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Dflat.Application.Services.JobServices;
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Dflat.Application.Repositories;
-using AutoMapper;
 using Dflat.Application.Models;
 using Moq;
 using System.Text.RegularExpressions;
@@ -27,21 +24,6 @@ namespace Dflat.Application.Services.JobServices.Tests
         private readonly Mock<IBackgroundJobRunner<FileSourceFolderScanJob>> _jobRunnerMock = new Mock<IBackgroundJobRunner<FileSourceFolderScanJob>>();
         #endregion
 
-        #region Constructor-set private fields
-        private readonly IMapper _mapper;
-        #endregion
-
-        public FileSourceFolderScanServiceTests()
-        {
-            var automapconfig = new MapperConfiguration(cfg =>
-            {
-
-                cfg.CreateMap<FileResult, Models.File>()
-                    .ForMember(dest => dest.FileID, opt => opt.MapFrom((src) => Guid.Empty))
-                    .ForMember(dest => dest.MD5Sum, opt => opt.MapFrom((src) => string.Empty));
-            });
-            _mapper = automapconfig.CreateMapper();
-        }
 
         [TestInitialize]
         public void Initialize()
@@ -59,7 +41,7 @@ namespace Dflat.Application.Services.JobServices.Tests
             var jobRepository = _jobRepositoryMock.Object;
             var jobRunner = _jobRunnerMock.Object;
 
-            var service = new FileSourceFolderScanService(fileSourceFolderRepository, fileRepository, folderScanner, _mapper, comparer, md5service, jobRepository, jobRunner)
+            var service = new FileSourceFolderScanService(fileSourceFolderRepository, fileRepository, folderScanner, comparer, md5service, jobRepository, jobRunner)
             {
                 EnableRunningJobs = true
             };

--- a/DflatMusicOrganizer/Dflat.Application/Dflat.Application.csproj
+++ b/DflatMusicOrganizer/Dflat.Application/Dflat.Application.csproj
@@ -2,7 +2,4 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="14.0.0" />
-  </ItemGroup>
 </Project>

--- a/DflatMusicOrganizer/Dflat.Application/Models/FileResultExtensions.cs
+++ b/DflatMusicOrganizer/Dflat.Application/Models/FileResultExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Dflat.Application.Models;
+
+public static class FileResultExtensions
+{
+    public static File ToNewFile(this FileResult fileResult) => new File
+    {
+        FileID = Guid.NewGuid(),
+        Filename = fileResult.Filename,
+        Extension = fileResult.Extension,
+        Directory = fileResult.Directory,
+        Size = fileResult.Size,
+        LastModifiedTime = fileResult.LastModifiedTime
+    };
+}

--- a/DflatMusicOrganizer/Dflat.Application/Services/JobServices/FileSourceFolderScanService.cs
+++ b/DflatMusicOrganizer/Dflat.Application/Services/JobServices/FileSourceFolderScanService.cs
@@ -1,5 +1,4 @@
-﻿using AutoMapper;
-using Dflat.Application.Models;
+﻿using Dflat.Application.Models;
 using Dflat.Application.Repositories;
 using System;
 using System.Collections.Generic;
@@ -15,7 +14,6 @@ namespace Dflat.Application.Services.JobServices
         private readonly IFileSourceFolderRepository fileSourceFolderRepository;
         private readonly IFileRepository fileRepository;
         private readonly IFolderSearchService folderScanner;
-        private readonly IMapper mapper;
         private readonly IFileCollectionCompare comparer;
         private readonly IJobService<MD5Job> md5Service;
         private readonly HashSet<string> validExtensions;
@@ -23,7 +21,6 @@ namespace Dflat.Application.Services.JobServices
         public FileSourceFolderScanService(IFileSourceFolderRepository fileSourceFolderRepository,
                                            IFileRepository fileRepository,
                                            IFolderSearchService folderScanner,
-                                           IMapper mapper,
                                            IFileCollectionCompare comparer,
                                            IJobService<MD5Job> md5Service,
                                            IJobRepository jobRepository,
@@ -34,7 +31,6 @@ namespace Dflat.Application.Services.JobServices
             this.fileSourceFolderRepository = fileSourceFolderRepository;
             this.fileRepository = fileRepository;
             this.folderScanner = folderScanner;
-            this.mapper = mapper;
             this.comparer = comparer;
             this.md5Service = md5Service;
             validExtensions = new HashSet<string>() { ".aiff", ".flac", ".m4a", ".mp2", ".mp3", ".ogg", ".wav", ".wma" };
@@ -130,8 +126,7 @@ namespace Dflat.Application.Services.JobServices
 
                 foreach (var fileResult in result.FoundFiles)
                 {
-                    Models.File newFile = mapper.Map<Models.File>(fileResult);
-                    newFile.FileID = Guid.NewGuid();
+                    Models.File newFile = fileResult.ToNewFile();
 
                     foundFiles.Add(newFile);
                 }

--- a/DflatMusicOrganizer/DflatCoreWPF/App.xaml.cs
+++ b/DflatMusicOrganizer/DflatCoreWPF/App.xaml.cs
@@ -1,5 +1,4 @@
-﻿using AutoMapper;
-using Dflat.Application.Models;
+﻿using Dflat.Application.Models;
 using Dflat.Application.Repositories;
 using Dflat.Application.Services;
 using Dflat.Application.Services.JobServices;
@@ -11,7 +10,6 @@ using DflatCoreWPF.Views;
 using DflatCoreWPF.WindowService;
 using Microsoft.Extensions.Configuration;
 using System;
-using System.Configuration;
 using System.IO;
 using System.Windows;
 using Unity;
@@ -43,34 +41,13 @@ namespace DflatCoreWPF
 
         private void Configure()
         {
-            var automapconfig = new MapperConfiguration(cfg =>
-            {
-
-                cfg.CreateMap<Dflat.Application.Models.FileSourceFolder, FileSourceFolderEditorViewModel>()
-                    .ForMember(dest => dest.SelectedExcludePath, opt => opt.Ignore())
-                    .ReverseMap()
-                    .DisableCtorValidation();
-
-                cfg.CreateMap<FileResult, Dflat.Application.Models.File>()
-                    .ForMember(dest => dest.FileID, opt => opt.MapFrom((src) => Guid.Empty))
-                    .ForMember(dest => dest.MD5Sum, opt => opt.MapFrom((src) => string.Empty));
-
-            });
-
-            //automapconfig.AssertConfigurationIsValid();
-
-
             var builder = new ConfigurationBuilder().SetBasePath(Directory.GetCurrentDirectory())
                 .AddJsonFile("appsettings.json");
 
             var config = builder.Build();
 
-            //string connectionString = config.GetConnectionString("DflatMusicOrganizerDB");
             string connectionString = config.GetConnectionString("DflatDB");
 
-
-            var mapper = automapconfig.CreateMapper();
-            container.RegisterInstance(mapper);
 
             container.RegisterSingleton<IWindowService, WindowService.WindowService>()
                 .RegisterSingleton<IJobService<FileSourceFolderScanJob>, FileSourceFolderScanService>()

--- a/DflatMusicOrganizer/DflatCoreWPF/DflatCoreWPF.csproj
+++ b/DflatMusicOrganizer/DflatCoreWPF/DflatCoreWPF.csproj
@@ -6,8 +6,6 @@
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="AutoMapper.Collection.EntityFrameworkCore" Version="11.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.2" />

--- a/DflatMusicOrganizer/DflatCoreWPF/ViewModels/FileSourceFolderEditorViewModel.cs
+++ b/DflatMusicOrganizer/DflatCoreWPF/ViewModels/FileSourceFolderEditorViewModel.cs
@@ -19,7 +19,17 @@ namespace DflatCoreWPF.ViewModels
             this.folderChooserDialog = folderChooserDialog;
         }
 
-
+        public void UseFileSourceFolder(FileSourceFolder fileSourceFolder)
+        {
+            FileSourceFolderID = fileSourceFolder.FileSourceFolderID;
+            Name = fileSourceFolder.Name;
+            Path = fileSourceFolder.Path;
+            IsTemporaryMedia = fileSourceFolder.IsTemporaryMedia;
+            LastScanStart = fileSourceFolder.LastScanStart;
+            IsChanged = fileSourceFolder.IsChanged;
+            // Copy exclude paths
+            ExcludePaths = new ObservableCollection<ExcludePath>(fileSourceFolder.ExcludePaths);
+        }
 
         #region Bindable properties
 

--- a/DflatMusicOrganizer/DflatCoreWPF/ViewModels/FileSourceManagerViewModel.cs
+++ b/DflatMusicOrganizer/DflatCoreWPF/ViewModels/FileSourceManagerViewModel.cs
@@ -1,5 +1,4 @@
-﻿using AutoMapper;
-using Dflat.Application.Models;
+﻿using Dflat.Application.Models;
 using Dflat.Application.Repositories;
 using Dflat.Application.Services.JobServices;
 using DflatCoreWPF.WindowService;
@@ -8,10 +7,8 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
-using System.Xml;
 
 namespace DflatCoreWPF.ViewModels
 {
@@ -23,7 +20,6 @@ namespace DflatCoreWPF.ViewModels
         private bool enableOverlay;
         private readonly IFileSourceFolderRepository fileSourceFolderRepository;
         private readonly IJobService<FileSourceFolderScanJob> fileSourceFolderScanService;
-        private readonly IMapper mapper;
         private readonly IWindowService windowService;
         private readonly ConfirmDialogViewModel confirmDialogViewModel;
         private readonly AlertDialogViewModel alertDialogViewModel;
@@ -39,7 +35,6 @@ namespace DflatCoreWPF.ViewModels
 
         public FileSourceManagerViewModel(IFileSourceFolderRepository fileSourceFolderRepository,
                                           IJobService<FileSourceFolderScanJob> fileSourceFolderScanService,
-                                          IMapper mapper,
                                           IWindowService windowService,
                                           ConfirmDialogViewModel confirmDialogViewModel,
                                           AlertDialogViewModel alertDialogViewModel,
@@ -50,7 +45,6 @@ namespace DflatCoreWPF.ViewModels
             this.changedFoldersToScan = new HashSet<FileSourceFolder>();
             this.fileSourceFolderRepository = fileSourceFolderRepository;
             this.fileSourceFolderScanService = fileSourceFolderScanService;
-            this.mapper = mapper;
             this.windowService = windowService;
             this.confirmDialogViewModel = confirmDialogViewModel;
             this.alertDialogViewModel = alertDialogViewModel;
@@ -181,12 +175,11 @@ namespace DflatCoreWPF.ViewModels
         {
             var currentFolder = new FileSourceFolder();
 
-            mapper.Map<FileSourceFolder, FileSourceFolderEditorViewModel>(currentFolder, sourceFolderEditorViewModel);
-            sourceFolderEditorViewModel.IsChanged = currentFolder.IsChanged;
+            sourceFolderEditorViewModel.UseFileSourceFolder(currentFolder);
             bool? acceptChanges = windowService.ShowDialog(sourceFolderEditorViewModel);
             if (acceptChanges == true)
             {
-                mapper.Map<FileSourceFolderEditorViewModel, FileSourceFolder>(sourceFolderEditorViewModel, currentFolder);
+                currentFolder.SetFromViewModel(sourceFolderEditorViewModel);
                 FileSourceFolders.Add(currentFolder);
             }
             RaisePropertyChanged(() => HasChanges);
@@ -200,12 +193,11 @@ namespace DflatCoreWPF.ViewModels
         {
             var currentFolder = SelectedFileSourceFolder;
 
-            mapper.Map<FileSourceFolder, FileSourceFolderEditorViewModel>(currentFolder, sourceFolderEditorViewModel);
-            sourceFolderEditorViewModel.IsChanged = currentFolder.IsChanged;
+            sourceFolderEditorViewModel.UseFileSourceFolder(currentFolder);
             bool? acceptChanges = windowService.ShowDialog(sourceFolderEditorViewModel);
             if (acceptChanges == true)
             {
-                mapper.Map<FileSourceFolderEditorViewModel, FileSourceFolder>(sourceFolderEditorViewModel, currentFolder);
+                currentFolder.SetFromViewModel(sourceFolderEditorViewModel);
             }
             RaisePropertyChanged(() => HasChanges);
             RaisePropertyChanged(() => CanSave);

--- a/DflatMusicOrganizer/DflatCoreWPF/ViewModels/ViewModelExtensions.cs
+++ b/DflatMusicOrganizer/DflatCoreWPF/ViewModels/ViewModelExtensions.cs
@@ -1,23 +1,22 @@
 ﻿using Dflat.Application.Models;
 
-namespace DflatCoreWPF.ViewModels
+namespace DflatCoreWPF.ViewModels;
+
+public static class ViewModelExtensions
 {
-    public static class ViewModelExtensions
+    public static void SetFromViewModel(this FileSourceFolder fileSourceFolder, FileSourceFolderEditorViewModel viewModel)
     {
-        public static void SetFromViewModel(this FileSourceFolder fileSourceFolder, FileSourceFolderEditorViewModel viewModel)
+        fileSourceFolder.FileSourceFolderID = viewModel.FileSourceFolderID;
+        fileSourceFolder.Name = viewModel.Name;
+        fileSourceFolder.Path = viewModel.Path;
+        fileSourceFolder.IsTemporaryMedia = viewModel.IsTemporaryMedia;
+        fileSourceFolder.LastScanStart = viewModel.LastScanStart;
+        fileSourceFolder.IsChanged = viewModel.IsChanged;
+        // Copy exclude paths
+        fileSourceFolder.ExcludePaths.Clear();
+        foreach (var excludePath in viewModel.ExcludePaths)
         {
-            fileSourceFolder.FileSourceFolderID = viewModel.FileSourceFolderID;
-            fileSourceFolder.Name = viewModel.Name;
-            fileSourceFolder.Path = viewModel.Path;
-            fileSourceFolder.IsTemporaryMedia = viewModel.IsTemporaryMedia;
-            fileSourceFolder.LastScanStart = viewModel.LastScanStart;
-            fileSourceFolder.IsChanged = viewModel.IsChanged;
-            // Copy exclude paths
-            fileSourceFolder.ExcludePaths.Clear();
-            foreach (var excludePath in viewModel.ExcludePaths)
-            {
-                fileSourceFolder.ExcludePaths.Add(excludePath);
-            }
+            fileSourceFolder.ExcludePaths.Add(excludePath);
         }
     }
 }

--- a/DflatMusicOrganizer/DflatCoreWPF/ViewModels/ViewModelExtensions.cs
+++ b/DflatMusicOrganizer/DflatCoreWPF/ViewModels/ViewModelExtensions.cs
@@ -1,0 +1,23 @@
+﻿using Dflat.Application.Models;
+
+namespace DflatCoreWPF.ViewModels
+{
+    public static class ViewModelExtensions
+    {
+        public static void SetFromViewModel(this FileSourceFolder fileSourceFolder, FileSourceFolderEditorViewModel viewModel)
+        {
+            fileSourceFolder.FileSourceFolderID = viewModel.FileSourceFolderID;
+            fileSourceFolder.Name = viewModel.Name;
+            fileSourceFolder.Path = viewModel.Path;
+            fileSourceFolder.IsTemporaryMedia = viewModel.IsTemporaryMedia;
+            fileSourceFolder.LastScanStart = viewModel.LastScanStart;
+            fileSourceFolder.IsChanged = viewModel.IsChanged;
+            // Copy exclude paths
+            fileSourceFolder.ExcludePaths.Clear();
+            foreach (var excludePath in viewModel.ExcludePaths)
+            {
+                fileSourceFolder.ExcludePaths.Add(excludePath);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Automapper was being used as a crutch to set fields on models and view models.  It was also being used to create new models.  This was obscuring the intention in different parts of the code.  Removing Automapper has made the code more readable.